### PR TITLE
on :push check if file exists on remote server and skip if it does

### DIFF
--- a/lib/capistrano/tasks/upload-config.rake
+++ b/lib/capistrano/tasks/upload-config.rake
@@ -42,8 +42,12 @@ namespace :config do
         fetch(:config_files).each do |config|
           local_path = CapistranoUploadConfig::Helpers.get_local_config_name(config, fetch(:stage).to_s)
           if File.exists?(local_path)
-            info "Uploading config #{local_path} as #{config}"
-            upload! StringIO.new(IO.read(local_path)), File.join(shared_path, config)
+            if test("[ ! -f " + File.join(shared_path, config) + " ]")
+              info "Uploading config #{local_path} as #{config}"
+              upload! StringIO.new(IO.read(local_path)), File.join(shared_path, config)
+            else
+              info File.join(shared_path, config) + " alredy exists on server, skipping upload"
+            end
           else
             fail "#{local_path} doesn't exist"
           end


### PR DESCRIPTION
on my setup, when there was an example file, the processing always overwritten the destination file with example content. Adding the check for remote file ensures that the file is created only on hosts that do not have it alredy (hence it will not squash local chenched alredy made on that file)
