### PR TITLE
Allow remote files to keep Stage Name in their path

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,21 @@ set :config_example_suffix, '.eg'
 
 Note, only suffixes (i.e. after the whole filename) are supported.
 
+#### Use Stage Name Remotely
+
+By default, capistrano-upload-config will remove the environment name from the
+file name for the server's version.  Occasionally, you'll want the server's file
+name to reflect the local file's name.
+
+```ruby
+# in deploy.rb
+
+set :config_use_stage_remotely, true
+set :config_files, [ ".env.php" ]
+```
+
+Running `cap staging config:push` will upload the remote file as
+`.env.staging.php`, rather than `.env.php`.
 
 ## Contributing
 

--- a/lib/capistrano/tasks/upload-config.rake
+++ b/lib/capistrano/tasks/upload-config.rake
@@ -39,11 +39,13 @@ namespace :config do
   task :push do
     on release_roles :all do
       within shared_path do
+        use_stage_remotely = fetch(:config_use_stage_remotely)
         fetch(:config_files).each do |config|
           local_path = CapistranoUploadConfig::Helpers.get_local_config_name(config, fetch(:stage).to_s)
+          server_name = use_stage_remotely ? local_path.split('/').last : config
           if File.exists?(local_path)
-            info "Uploading config #{local_path} as #{config}"
-            upload! StringIO.new(IO.read(local_path)), File.join(shared_path, config)
+            info "Uploading config #{local_path} as #{server_name}"
+            upload! StringIO.new(IO.read(local_path)), File.join(shared_path, server_name)
           else
             fail "#{local_path} doesn't exist"
           end
@@ -56,10 +58,12 @@ namespace :config do
   task :pull do
     on release_roles :all do
       within shared_path do
+        use_stage_remotely = fetch(:config_use_stage_remotely)
         fetch(:config_files).each do |config|
           local_path = CapistranoUploadConfig::Helpers.get_local_config_name(config, fetch(:stage).to_s)
-          info "Downloading config #{config} as #{local_path} "
-          download! File.join(shared_path, config), local_path
+          server_name = use_stage_remotely ? local_path.split('/').last : config
+          info "Downloading config #{server_name} as #{local_path} "
+          download! File.join(shared_path, server_name), local_path
         end
       end
     end
@@ -74,6 +78,7 @@ namespace :load do
     set :config_example_suffix, '-example'
     # https://github.com/rjocoleman/capistrano-upload-config/issues/1
     set :config_example_prefix, -> { fetch(:config_example_suffix) }
+    set :config_use_stage_remotely, false
 
   end
 end


### PR DESCRIPTION
Thought this might be useful for others!

I'm using the Themosis wordpress MVC framework - it expects an .env file named after it's current environment.

