### PR TITLE
Revert "Modified the path helper to resolve the absolute path of the file to …"

### DIFF
--- a/lib/capistrano/upload-config.rb
+++ b/lib/capistrano/upload-config.rb
@@ -11,7 +11,7 @@ module CapistranoUploadConfig
         extension.sub!(/^\./, '')
         local_file = [filename, stage].join('.')
         local_file = [local_file, extension].join('.') unless extension.empty?
-        local_path = File.readlink(File.join(path, local_file))
+        local_path = File.join(path, local_file)
       end
 
     end


### PR DESCRIPTION
Reverts rjocoleman/capistrano-upload-config#11

This doesn't work with non-symlinks, so it's being reverted until a solution that is backwards compatible can be found.